### PR TITLE
Redirects from /gadget -> /gadget2

### DIFF
--- a/gadget/docs/userguide/index.html
+++ b/gadget/docs/userguide/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=/gadget2/docs/userguide/" />
+  </head>
+  <body>
+    <a href="/gadget2/docs/userguide/">The repository has moved</a>
+  </body>
+</html>

--- a/gadget/index.html
+++ b/gadget/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=/gadget2/" />
+  </head>
+  <body>
+    <a href="/gadget2/">The repository has moved</a>
+  </body>
+</html>


### PR DESCRIPTION
Apparently Github doesn't do this automatically for us, so add some redirects manually.